### PR TITLE
Avoid pushing base layers

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1972,6 +1972,7 @@ func (s *StageExecutor) pushCache(ctx context.Context, src, cacheKey string) err
 	for _, dest := range destList {
 		logrus.Debugf("trying to push cache to dest: %+v from src:%+v", dest, src)
 		options := buildah.PushOptions{
+			Logger:              s.executor.logger,
 			Compression:         s.executor.compression,
 			SignaturePolicyPath: s.executor.signaturePolicyPath,
 			Store:               s.executor.store,
@@ -2004,6 +2005,7 @@ func (s *StageExecutor) pullCache(ctx context.Context, cacheKey string) (referen
 	for _, src := range srcList {
 		logrus.Debugf("trying to pull cache from remote repo: %+v", src.DockerReference())
 		options := buildah.PullOptions{
+			Logger:              s.executor.logger,
 			SignaturePolicyPath: s.executor.signaturePolicyPath,
 			Store:               s.executor.store,
 			SystemContext:       s.executor.systemContext,

--- a/push.go
+++ b/push.go
@@ -1,15 +1,22 @@
 package buildah
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/containers/buildah/pkg/blobcache"
 	"github.com/containers/common/libimage"
+	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/blobinfocache"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
@@ -17,6 +24,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,6 +48,7 @@ func cacheLookupReferenceFunc(directory string, compress types.LayerCompression)
 
 // PushOptions can be used to alter how an image is copied somewhere.
 type PushOptions struct {
+	Logger *logrus.Logger
 	// Compression specifies the type of compression which is applied to
 	// layer blobs.  The default is to not use compression, but
 	// archive.Gzip is recommended.
@@ -122,10 +131,19 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 	}
 
 	compress := types.PreserveOriginal
-	if options.Compression == archive.Gzip {
+	if options.Compression == archive.Gzip || options.Compression == archive.Zstd {
 		compress = types.Compress
 	}
-	libimageOptions.SourceLookupReferenceFunc = cacheLookupReferenceFunc(options.BlobDirectory, compress)
+	realBlobCache := cacheLookupReferenceFunc(options.BlobDirectory, compress)
+	libimageOptions.SourceLookupReferenceFunc = func(ref types.ImageReference) (types.ImageReference, error) {
+		options.Logger.Debugf("Looking up source image %q %q", ref.Transport().Name(), ref.StringWithinTransport())
+		src, err := realBlobCache(ref)
+		return stubbedBlobsImageReference{
+			ImageReference: src,
+			destRef:        dest,
+			logger:         options.Logger,
+		}, err
+	}
 
 	runtime, err := libimage.RuntimeFromStore(options.Store, &libimage.RuntimeOptions{SystemContext: options.SystemContext})
 	if err != nil {
@@ -152,4 +170,105 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 	}
 
 	return ref, manifestDigest, nil
+}
+
+type stubbedBlobsImageReference struct {
+	types.ImageReference
+	destRef types.ImageReference
+	logger  *logrus.Logger
+}
+
+func (ref stubbedBlobsImageReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	src, err := ref.ImageReference.NewImageSource(ctx, sys)
+	return stubbedBlobsImageSource{
+		ImageSource: src,
+		destRef:     ref.destRef,
+		logger:      ref.logger,
+		cache:       blobinfocache.DefaultCache(sys),
+	}, err
+}
+
+type stubbedBlobsImageSource struct {
+	types.ImageSource
+	destRef types.ImageReference
+	logger  *logrus.Logger
+	cache   types.BlobInfoCache
+}
+
+func (src stubbedBlobsImageSource) LayerInfosForCopy(ctx context.Context, instanceDigest *digest.Digest) ([]types.BlobInfo, error) {
+	updatedBlobInfos := []types.BlobInfo{}
+	infos, err := src.ImageSource.LayerInfosForCopy(ctx, instanceDigest)
+	if err != nil {
+		return nil, err
+	}
+	if infos == nil {
+		return nil, nil
+	}
+
+	manifestBlob, manifestType, err := src.GetManifest(ctx, instanceDigest)
+	if err != nil {
+		return nil, fmt.Errorf("reading image manifest: %w", err)
+	}
+	if manifest.MIMETypeIsMultiImage(manifestType) {
+		return nil, errors.New("can't copy layers for a manifest list (shouldn't be attempted)")
+	}
+
+	var manifestStub struct {
+		Annotations map[string]string `json:"annotations"`
+	}
+	if err := json.Unmarshal(manifestBlob, &manifestStub); err != nil {
+		return nil, fmt.Errorf("parsing image manifest in LayerInfosForCopy: %w", err)
+	}
+
+	baseImageRegistry := ""
+	if baseImage, ok := manifestStub.Annotations["org.opencontainers.image.base.name"]; ok {
+		if registry, _, ok := strings.Cut(baseImage, "/"); ok {
+			baseImageRegistry = registry
+			src.logger.Debugf("found base image registry %s", baseImageRegistry)
+		}
+	}
+
+	destRegistry := reference.Domain(src.destRef.DockerReference())
+
+	changed := false
+	for _, layerBlob := range infos {
+		src.logger.Debugf("blob %s", layerBlob.Digest)
+		var candidates []types.BICReplacementCandidate
+		if baseImageRegistry != "" {
+			candidates = src.cache.CandidateLocations(docker.Transport, types.BICTransportScope{Opaque: baseImageRegistry}, layerBlob.Digest, true)
+		}
+		if len(candidates) == 0 {
+			candidates = src.cache.CandidateLocations(docker.Transport, types.BICTransportScope{Opaque: destRegistry}, layerBlob.Digest, false)
+		}
+		if len(candidates) > 0 {
+			// We have a cached blob reference for this layer - that means
+			// we've pulled or pushed it before and there's no need to push
+			// it to cache.
+			src.logger.Debugf("stubbing layer %s", layerBlob.Digest)
+			blobInfo := types.BlobInfo{
+				Digest:    image.GzippedEmptyLayerDigest,
+				Size:      int64(len(image.GzippedEmptyLayer)),
+				MediaType: imgspecv1.MediaTypeImageLayerGzip,
+				Annotations: map[string]string{
+					diffIDAnnotation: layerBlob.Digest.String(),
+				},
+			}
+			updatedBlobInfos = append(updatedBlobInfos, blobInfo)
+			changed = true
+		} else {
+			updatedBlobInfos = append(updatedBlobInfos, layerBlob)
+		}
+	}
+	if changed {
+		return updatedBlobInfos, nil
+	}
+	return infos, nil
+}
+
+func (src stubbedBlobsImageSource) GetBlob(ctx context.Context, info types.BlobInfo, infoCache types.BlobInfoCache) (io.ReadCloser, int64, error) {
+	if info.Digest == image.GzippedEmptyLayerDigest {
+		src.logger.Debugf("returning empty blob")
+		return io.NopCloser(bytes.NewReader(image.GzippedEmptyLayer)), int64(len(image.GzippedEmptyLayer)), nil
+	}
+	return src.ImageSource.GetBlob(ctx, info, infoCache)
 }


### PR DESCRIPTION
When we detect a layer we pushed before, stub in an empty layer, with an annotation containing the uncompressed layer DiffID it's replacing. On pull, swap in the uncompressed layer digest so the actual layer in the layer store will be used without trying to pull/use the empty layer.